### PR TITLE
feat: clear others pronouns

### DIFF
--- a/src/main/java/cat/rezelyn/watheextended/command/PronounsCommand.java
+++ b/src/main/java/cat/rezelyn/watheextended/command/PronounsCommand.java
@@ -4,6 +4,7 @@ import cat.rezelyn.watheextended.game.PronounsManager;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
+import net.minecraft.command.argument.EntityArgumentType;
 import net.minecraft.server.command.CommandManager;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
@@ -32,7 +33,15 @@ public final class PronounsCommand {
             broadcastAll(context.getSource(), uuid, "");
             context.getSource().sendFeedback(() -> Text.translatable("command.watheextended.pronouns.cleared"), false);
             return 1;
-        })));
+        }).then(CommandManager.argument("targets", EntityArgumentType.entities()).requires(source -> source.hasPermissionLevel(2)).executes(context -> {
+            for (ServerPlayerEntity player : EntityArgumentType.getPlayers(context, "targets")) {
+                UUID uuid = player.getUuid();
+                PronounsManager.clear(uuid);
+                broadcastAll(context.getSource(), uuid, "");
+                context.getSource().sendFeedback(() -> Text.translatable("command.watheextended.pronouns.cleared_other", player.getName()), true);
+            }
+            return 1;
+        }))));
     }
 
     public static void broadcastAll(ServerCommandSource source, UUID uuid, String pronouns) {

--- a/src/main/resources/assets/watheextended/lang/en_us.json
+++ b/src/main/resources/assets/watheextended/lang/en_us.json
@@ -101,6 +101,7 @@
 
   "command.watheextended.pronouns.set": "Your pronouns have been set to: %s",
   "command.watheextended.pronouns.cleared": "Your pronouns have been cleared.",
+  "command.watheextended.pronouns.cleared_other": "%ss pronouns have been cleared.",
   "command.watheextended.mapvariables.lobbyarea.set": "Map variable lobbyArea successfully set to:\n%s.",
   "command.watheextended.rtp_slot.added": "Added teleportation slot #%d (%s)",
   "command.watheextended.rtp_slot.edited": "Updated teleportation slot #%d (%s)",

--- a/src/main/resources/assets/watheextended/lang/fr_fr.json
+++ b/src/main/resources/assets/watheextended/lang/fr_fr.json
@@ -56,6 +56,7 @@
   "announcement.modifier.watheextended.adaptive": "Adaptive",
   "command.watheextended.pronouns.set": "Vos pronoms ont été configurés sur : %s",
   "command.watheextended.pronouns.cleared": "Vos pronoms ont été effacés.",
+  "command.watheextended.pronouns.cleared_other": "Les pronoms de %s ont été effacés.",
   "command.watheextended.mapvariables.lobbyarea.set": "Variable de carte lobbyArea définie sur %s.",
   "command.watheextended.rtp_slot.added": "Emplacement de téléportation #%d ajouté (%s)",
   "command.watheextended.rtp_slot.edited": "Emplacement de téléportation #%d mis à jour (%s)",

--- a/src/main/resources/assets/watheextended/lang/zh_cn.json
+++ b/src/main/resources/assets/watheextended/lang/zh_cn.json
@@ -56,6 +56,7 @@
   "announcement.modifier.watheextended.adaptive": "Adaptive",
   "command.watheextended.pronouns.set": "Your pronouns have been set to: %s",
   "command.watheextended.pronouns.cleared": "Your pronouns have been cleared.",
+  "command.watheextended.pronouns.cleared_other": "%ss pronouns have been cleared.",
   "command.watheextended.mapvariables.lobbyarea.set": "地图变量大厅区域已成功设置为 %s。",
   "command.watheextended.rtp_slot.added": "已添加传送槽位 #%d (%s)",
   "command.watheextended.rtp_slot.edited": "已更新传送槽位 #%d (%s)",


### PR DESCRIPTION
Operators have the ability to clear the pronouns of a specific player or multiple players
This is useful for if a player uses the pronouns mechanic in an ill intended way and not for its original purpose
`/pronouns clear [<targets>]`